### PR TITLE
Temp fix of create modal not being scrollable

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -73,7 +73,6 @@ const ModalContent = styled('div')`
     p.small &&
     `
     width: auto;
-    height: auto;
   `};
 `
 


### PR DESCRIPTION
This is to enable scroll on create popup modal.

I am aware that this makes the sign in and  confirmation modal look ugly but better than not being able to create an account at all, so will put in as an emergency fix.

This still needs to be fixed